### PR TITLE
[Postgres] Add configurable table name support with explicit configur…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,13 @@ coverage.out
 *.dylib
 main
 
+# Example binaries
+examples/*/main
+examples/*/*.exe
+examples/custom-table-example/custom-table-example
+examples/postgres-example/postgres-example
+examples/hello-world/hello-world
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/README.md
+++ b/README.md
@@ -95,21 +95,40 @@ import (
 )
 
 func main() {
-    // Create a PostgreSQL event store
-    store, err := postgres.NewPostgresEventStore("host=localhost port=5432 user=postgres password=password dbname=eventstore sslmode=disable")
+    // Create a PostgreSQL event store (default table name is "events")
+    store, err := postgres.NewPostgresEventStore(postgres.Config{
+        ConnectionString: "host=localhost port=5432 user=postgres password=password dbname=eventstore sslmode=disable",
+        TableName:        "my_custom_events", // Custom table name
+    })
     if err != nil {
         panic(err)
     }
     defer store.Close()
     
-    // Use the same interface as in-memory...
-    // The rest of the code is identical!
+    // Initialize schema with custom table name
+    if err := store.InitSchema(); err != nil {
+        panic(err)
+    }
+    
+    // Use the same interface as before...
 }
 ```
 
-### Running the Example
+### Running the Examples
 
 See the [hello-world example](examples/hello-world/) for a complete demonstration of both backends.
+
+### Running PostgreSQL Examples
+
+Make sure you have PostgreSQL running:
+
+```bash
+# Start PostgreSQL for testing
+make start-postgres
+
+# Run the basic PostgreSQL example
+make run-postgres-example
+```
 
 ## 📋 MVP Scope
 

--- a/examples/postgres-example/README.md
+++ b/examples/postgres-example/README.md
@@ -37,6 +37,16 @@ docker run --name postgres-eventstore \
    go run main.go -postgres-conn="host=localhost port=5432 user=myuser password=mypass dbname=mydb sslmode=disable"
    ```
 
+4. Run with custom table name:
+   ```bash
+   go run main.go -table-name="my_custom_events"
+   ```
+
+5. Run with both custom connection and table name:
+   ```bash
+   go run main.go -postgres-conn="host=localhost port=5432 user=myuser password=mypass dbname=mydb sslmode=disable" -table-name="user_events"
+   ```
+
 ## What the Example Does
 
 1. **Connects to PostgreSQL**: Establishes connection to the PostgreSQL database
@@ -53,6 +63,7 @@ docker run --name postgres-eventstore \
 - **Metadata Support**: Custom metadata is stored as JSONB
 - **Optimistic Concurrency**: Expected version checks prevent conflicts
 - **Query Options**: Loading events with version filtering and limits
+- **Custom Table Names**: Support for configurable table names (instead of default 'events')
 
 ## Output
 

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -4,20 +4,30 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	_ "github.com/lib/pq" // PostgreSQL driver
 	"github.com/shogotsuneto/go-simple-eventstore"
 )
 
-// PostgresEventStore is a PostgreSQL implementation of EventStore.
-type PostgresEventStore struct {
-	db *sql.DB
+// Config contains configuration options for PostgresEventStore.
+type Config struct {
+	// ConnectionString is the PostgreSQL connection string
+	ConnectionString string
+	// TableName is the name of the table to store events. Defaults to "events" if empty.
+	TableName string
 }
 
-// NewPostgresEventStore creates a new PostgreSQL event store.
-func NewPostgresEventStore(connectionString string) (*PostgresEventStore, error) {
-	db, err := sql.Open("postgres", connectionString)
+// PostgresEventStore is a PostgreSQL implementation of EventStore.
+type PostgresEventStore struct {
+	db        *sql.DB
+	tableName string
+}
+
+// NewPostgresEventStore creates a new PostgreSQL event store with the given configuration.
+func NewPostgresEventStore(config Config) (*PostgresEventStore, error) {
+	db, err := sql.Open("postgres", config.ConnectionString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database connection: %w", err)
 	}
@@ -26,9 +36,26 @@ func NewPostgresEventStore(connectionString string) (*PostgresEventStore, error)
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
-	store := &PostgresEventStore{db: db}
+	tableName := config.TableName
+	if tableName == "" {
+		tableName = "events"
+	}
+
+	store := &PostgresEventStore{
+		db:        db,
+		tableName: tableName,
+	}
 
 	return store, nil
+}
+
+// quoteIdentifier properly quotes a PostgreSQL identifier (table name, column name, etc.)
+// to handle special characters and prevent SQL injection.
+func quoteIdentifier(identifier string) string {
+	// Replace any double quotes with double-double quotes to escape them
+	escaped := strings.ReplaceAll(identifier, `"`, `""`)
+	// Wrap in double quotes
+	return `"` + escaped + `"`
 }
 
 // Close closes the database connection.
@@ -38,8 +65,9 @@ func (s *PostgresEventStore) Close() error {
 
 // InitSchema creates the necessary tables and indexes if they don't exist.
 func (s *PostgresEventStore) InitSchema() error {
-	query := `
-	CREATE TABLE IF NOT EXISTS events (
+	tableName := quoteIdentifier(s.tableName)
+	query := fmt.Sprintf(`
+	CREATE TABLE IF NOT EXISTS %s (
 		id SERIAL PRIMARY KEY,
 		stream_id VARCHAR(255) NOT NULL,
 		version BIGINT NOT NULL,
@@ -50,9 +78,11 @@ func (s *PostgresEventStore) InitSchema() error {
 		timestamp TIMESTAMP WITH TIME ZONE NOT NULL
 	);
 
-	CREATE INDEX IF NOT EXISTS idx_events_stream_id ON events(stream_id);
-	CREATE UNIQUE INDEX IF NOT EXISTS idx_events_stream_version ON events(stream_id, version);
-	`
+	CREATE INDEX IF NOT EXISTS %s ON %s(stream_id);
+	CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s(stream_id, version);
+	`, tableName,
+		quoteIdentifier("idx_"+s.tableName+"_stream_id"), tableName,
+		quoteIdentifier("idx_"+s.tableName+"_stream_version"), tableName)
 
 	_, err := s.db.Exec(query)
 	return err
@@ -78,7 +108,7 @@ func (s *PostgresEventStore) Append(streamID string, events []eventstore.Event, 
 
 	// Get the current maximum version for this stream
 	var maxVersion int64
-	err = tx.QueryRow("SELECT COALESCE(MAX(version), 0) FROM events WHERE stream_id = $1", streamID).Scan(&maxVersion)
+	err = tx.QueryRow(fmt.Sprintf("SELECT COALESCE(MAX(version), 0) FROM %s WHERE stream_id = $1", quoteIdentifier(s.tableName)), streamID).Scan(&maxVersion)
 	if err != nil {
 		return fmt.Errorf("failed to get max version: %w", err)
 	}
@@ -101,10 +131,10 @@ func (s *PostgresEventStore) Append(streamID string, events []eventstore.Event, 
 	}
 
 	// Prepare the insert statement
-	stmt, err := tx.Prepare(`
-		INSERT INTO events (stream_id, version, event_id, event_type, event_data, metadata, timestamp)
+	stmt, err := tx.Prepare(fmt.Sprintf(`
+		INSERT INTO %s (stream_id, version, event_id, event_type, event_data, metadata, timestamp)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
-	`)
+	`, quoteIdentifier(s.tableName)))
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
@@ -143,12 +173,12 @@ func (s *PostgresEventStore) Append(streamID string, events []eventstore.Event, 
 
 // Load retrieves events for the given stream using the specified options.
 func (s *PostgresEventStore) Load(streamID string, opts eventstore.LoadOptions) ([]eventstore.Event, error) {
-	query := `
+	query := fmt.Sprintf(`
 		SELECT event_id, event_type, event_data, metadata, timestamp, version
-		FROM events
+		FROM %s
 		WHERE stream_id = $1 AND version > $2
 		ORDER BY version ASC
-	`
+	`, quoteIdentifier(s.tableName))
 
 	args := []interface{}{streamID, opts.FromVersion}
 

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -1,0 +1,126 @@
+package postgres
+
+import (
+	"testing"
+)
+
+func TestQuoteIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple table name",
+			input:    "events",
+			expected: `"events"`,
+		},
+		{
+			name:     "table name with underscores",
+			input:    "custom_events",
+			expected: `"custom_events"`,
+		},
+		{
+			name:     "table name with spaces",
+			input:    "my events",
+			expected: `"my events"`,
+		},
+		{
+			name:     "table name with double quotes",
+			input:    `table"name`,
+			expected: `"table""name"`,
+		},
+		{
+			name:     "table name with multiple double quotes",
+			input:    `"table""name"`,
+			expected: `"""table""""name"""`,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: `""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := quoteIdentifier(tt.input)
+			if result != tt.expected {
+				t.Errorf("quoteIdentifier(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfig_TableName(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        Config
+		expectedTable string
+	}{
+		{
+			name: "default table name when empty",
+			config: Config{
+				ConnectionString: "test-conn",
+				TableName:        "",
+			},
+			expectedTable: "events",
+		},
+		{
+			name: "custom table name",
+			config: Config{
+				ConnectionString: "test-conn",
+				TableName:        "custom_events",
+			},
+			expectedTable: "custom_events",
+		},
+		{
+			name: "table name with underscores",
+			config: Config{
+				ConnectionString: "test-conn",
+				TableName:        "my_custom_event_table",
+			},
+			expectedTable: "my_custom_event_table",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// We can't actually create a database connection in unit tests,
+			// so we'll just test the table name assignment logic
+			tableName := tt.config.TableName
+			if tableName == "" {
+				tableName = "events"
+			}
+
+			if tableName != tt.expectedTable {
+				t.Errorf("Expected table name %s, got %s", tt.expectedTable, tableName)
+			}
+		})
+	}
+}
+
+func TestNewPostgresEventStore_InvalidConnection(t *testing.T) {
+	// This test verifies that invalid connection strings return errors
+	config := Config{
+		ConnectionString: "invalid-connection-string",
+		TableName:        "events",
+	}
+	_, err := NewPostgresEventStore(config)
+	if err == nil {
+		t.Error("Expected error for invalid connection string")
+	}
+}
+
+func TestNewPostgresEventStore_InvalidConnectionWithCustomTable(t *testing.T) {
+	// Test that invalid connection strings return errors with custom table names
+	config := Config{
+		ConnectionString: "invalid-connection-string",
+		TableName:        "custom_events",
+	}
+
+	_, err := NewPostgresEventStore(config)
+	if err == nil {
+		t.Error("Expected error for invalid connection string")
+	}
+}


### PR DESCRIPTION
…ation API (#23)

* Initial plan

* Implement configurable table name for PostgreSQL event store



* Add SQL identifier quoting and update documentation



* Remove build artifacts and update gitignore



* Address review feedback: remove custom-table-example, improve postgres-example, simplify integration tests



* Update README.md per review feedback: simplify PostgreSQL examples and remove references to removed custom-table-example



* Add Load tests to custom table integration tests per review feedback



* Remove quotePgIdentifier from tests and use explicit quoted table names



* Remove unnecessary ReplaceAll call from custom table name test



* Remove NewPostgresEventStore convenience function and rename NewPostgresEventStoreWithConfig to NewPostgresEventStore



---------