### PR TITLE
Remove default table name from PostgreSQL implementation and allow Po…

### DIFF
--- a/examples/postgres-example/main.go
+++ b/examples/postgres-example/main.go
@@ -27,9 +27,9 @@ type UserEmailChanged struct {
 }
 
 func main() {
-	// Command-line flags for PostgreSQL connection and custom table name
+	// Command-line flags for PostgreSQL connection and table name
 	var pgConnStr = flag.String("postgres-conn", "host=localhost port=5432 user=test password=test dbname=eventstore_test sslmode=disable", "PostgreSQL connection string")
-	var tableName = flag.String("table-name", "", "Custom table name for storing events (uses default 'events' if not specified)")
+	var tableName = flag.String("table-name", "events", "Table name for storing events (required)")
 	flag.Parse()
 
 	fmt.Println("🚀 Go Simple EventStore - PostgreSQL Example")
@@ -53,17 +53,16 @@ func main() {
 	}
 
 	// Initialize the database schema
-	if *tableName != "" {
-		fmt.Printf("🔧 Initializing database schema with table '%s'...\n", *tableName)
-	} else {
-		fmt.Println("🔧 Initializing database schema with default table 'events'...")
-	}
+	fmt.Printf("🔧 Initializing database schema with table '%s'...\n", *tableName)
 	if err := postgres.InitSchema(db, *tableName); err != nil {
 		log.Fatalf("Failed to initialize schema: %v", err)
 	}
 
 	// Create PostgreSQL event store
-	store = postgres.NewPostgresEventStore(db, *tableName)
+	store, err = postgres.NewPostgresEventStore(db, *tableName)
+	if err != nil {
+		log.Fatalf("Failed to create PostgreSQL event store: %v", err)
+	}
 
 	fmt.Println("✅ PostgreSQL event store ready")
 
@@ -179,10 +178,6 @@ func main() {
 
 	fmt.Println("\n🎉 PostgreSQL example completed successfully!")
 
-	if *tableName != "" {
-		fmt.Printf("💡 Events were stored in custom table '%s'. You can run this example with different table names using the -table-name flag.\n", *tableName)
-	} else {
-		fmt.Println("💡 Events were stored in the default 'events' table. You can use a custom table name with the -table-name flag.")
-		fmt.Println("   Example: go run main.go -table-name=my_custom_events")
-	}
+	fmt.Printf("💡 Events were stored in table '%s'. You can run this example with different table names using the -table-name flag.\n", *tableName)
+	fmt.Println("   Example: go run main.go -table-name=my_custom_events")
 }

--- a/integration_test/postgres_consumer_integration_test.go
+++ b/integration_test/postgres_consumer_integration_test.go
@@ -32,8 +32,14 @@ func setupTestConsumerWithTableName(t *testing.T, tableName string, pollingInter
 		t.Fatalf("Failed to initialize schema: %v", err)
 	}
 
-	store := postgres.NewPostgresEventStore(db, tableName)
-	consumer := postgres.NewPostgresEventConsumer(db, tableName, pollingInterval)
+	store, err := postgres.NewPostgresEventStore(db, tableName)
+	if err != nil {
+		t.Fatalf("Failed to create PostgreSQL event store: %v", err)
+	}
+	consumer, err := postgres.NewPostgresEventConsumer(db, tableName, pollingInterval)
+	if err != nil {
+		t.Fatalf("Failed to create PostgreSQL event consumer: %v", err)
+	}
 	return consumer, store, db
 }
 

--- a/integration_test/postgres_integration_test.go
+++ b/integration_test/postgres_integration_test.go
@@ -41,7 +41,10 @@ func setupTestStore(t *testing.T, tableName string) (eventstore.EventStore, *sql
 		t.Fatalf("Failed to initialize schema: %v", err)
 	}
 
-	store := postgres.NewPostgresEventStore(db, tableName)
+	store, err := postgres.NewPostgresEventStore(db, tableName)
+	if err != nil {
+		t.Fatalf("Failed to create PostgreSQL event store: %v", err)
+	}
 	return store, db
 }
 
@@ -88,7 +91,7 @@ func countEventsInTable(t *testing.T, connectionString, tableName string) int {
 }
 
 func TestPostgresEventStore_Integration_Append(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 	defer db.Close()
 
@@ -159,7 +162,7 @@ func TestPostgresEventStore_Integration_Append(t *testing.T) {
 }
 
 func TestPostgresEventStore_Integration_Load_EmptyStream(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 	defer db.Close()
 
@@ -175,7 +178,7 @@ func TestPostgresEventStore_Integration_Load_EmptyStream(t *testing.T) {
 }
 
 func TestPostgresEventStore_Integration_Load_WithVersion(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 
 	// Add some events
@@ -210,7 +213,7 @@ func TestPostgresEventStore_Integration_Load_WithVersion(t *testing.T) {
 }
 
 func TestPostgresEventStore_Integration_Load_WithLimit(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 
 	// Add some events
@@ -247,7 +250,7 @@ func TestPostgresEventStore_Integration_Load_WithLimit(t *testing.T) {
 
 
 func TestPostgresEventStore_Integration_ConcurrentAppends(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 
 	streamID := "concurrent-test-stream-" + time.Now().Format("20060102150405")
@@ -298,7 +301,7 @@ func TestPostgresEventStore_Integration_ConcurrentAppends(t *testing.T) {
 }
 
 func TestPostgresEventStore_Integration_ExpectedVersion_NewStream(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 
 	streamID := "expected-version-new-stream-" + time.Now().Format("20060102150405")
@@ -335,7 +338,7 @@ func TestPostgresEventStore_Integration_ExpectedVersion_NewStream(t *testing.T) 
 }
 
 func TestPostgresEventStore_Integration_ExpectedVersion_ExactMatch(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 
 	streamID := "expected-version-exact-match-" + time.Now().Format("20060102150405")
@@ -392,7 +395,7 @@ func TestPostgresEventStore_Integration_ExpectedVersion_ExactMatch(t *testing.T)
 }
 
 func TestPostgresEventStore_Integration_ExpectedVersion_NoCheck(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 
 	streamID := "expected-version-no-check-" + time.Now().Format("20060102150405")
@@ -432,7 +435,7 @@ func TestPostgresEventStore_Integration_ExpectedVersion_NoCheck(t *testing.T) {
 }
 
 func TestPostgresEventStore_Integration_ConcurrencyConflictErrors(t *testing.T) {
-	store, db := setupTestStore(t, "")
+	store, db := setupTestStore(t, "test_events")
 	defer db.Close()
 
 	streamID := "conflict-test-stream-" + time.Now().Format("20060102150405")
@@ -587,54 +590,5 @@ func TestPostgresEventStore_Integration_CustomTableName(t *testing.T) {
 
 	if loadedEvents[0].Type != "TestEvent" {
 		t.Errorf("Expected event type 'TestEvent', got '%s'", loadedEvents[0].Type)
-	}
-}
-
-
-
-func TestPostgresEventStore_Integration_EmptyTableName_UsesDefault(t *testing.T) {
-	// Test that empty table name uses default "events"
-	connStr := getTestConnectionString()
-	
-	store, db := setupTestStore(t, "")
-	defer db.Close()
-
-	// Check that the default "events" table was created (not a custom one)
-	if !checkTableExists(t, connStr, "events") {
-		t.Fatalf("Default 'events' table should exist when using empty table name")
-	}
-
-	// Append a single event to test functionality
-	events := []eventstore.Event{
-		{
-			Type: "EmptyTableNameTest",
-			Data: []byte(`{"test": "empty_table_name"}`),
-		},
-	}
-
-	streamID := "empty-table-name-test-" + time.Now().Format("20060102150405")
-	err := store.Append(streamID, events, -1)
-	if err != nil {
-		t.Fatalf("Append failed with empty table name: %v", err)
-	}
-
-	// Check that event was stored in the default "events" table
-	eventCount := countEventsInTable(t, connStr, `"events"`)
-	if eventCount == 0 {
-		t.Errorf("Expected at least 1 event in default 'events' table, got %d", eventCount)
-	}
-
-	// Test that Load also works with the default table name
-	loadedEvents, err := store.Load(streamID, eventstore.LoadOptions{AfterVersion: 0, Limit: 10})
-	if err != nil {
-		t.Fatalf("Load failed from default table: %v", err)
-	}
-
-	if len(loadedEvents) != 1 {
-		t.Fatalf("Expected 1 event loaded from default table, got %d", len(loadedEvents))
-	}
-
-	if loadedEvents[0].Type != "EmptyTableNameTest" {
-		t.Errorf("Expected event type 'EmptyTableNameTest', got '%s'", loadedEvents[0].Type)
 	}
 }

--- a/postgres/consumer.go
+++ b/postgres/consumer.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sync"
 	"time"
 
@@ -18,9 +19,10 @@ type PostgresEventConsumer struct {
 }
 
 // NewPostgresEventConsumer creates a new PostgreSQL event consumer with the given database connection, table name, and polling interval.
-func NewPostgresEventConsumer(db *sql.DB, tableName string, pollingInterval time.Duration) eventstore.EventConsumer {
+// tableName must not be empty.
+func NewPostgresEventConsumer(db *sql.DB, tableName string, pollingInterval time.Duration) (eventstore.EventConsumer, error) {
 	if tableName == "" {
-		tableName = "events"
+		return nil, fmt.Errorf("table name must not be empty")
 	}
 
 	if pollingInterval <= 0 {
@@ -34,7 +36,7 @@ func NewPostgresEventConsumer(db *sql.DB, tableName string, pollingInterval time
 		},
 		subscriptions:   []*PostgresSubscription{}, // Changed to a single slice
 		pollingInterval: pollingInterval,
-	}
+	}, nil
 }
 
 // Retrieve retrieves events from all streams in a retrieval operation.

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -12,9 +12,10 @@ import (
 
 // InitSchema creates the necessary tables and indexes if they don't exist.
 // It takes a database connection and table name to initialize the schema.
+// tableName must not be empty.
 func InitSchema(db *sql.DB, tableName string) error {
 	if tableName == "" {
-		tableName = "events"
+		return fmt.Errorf("table name must not be empty")
 	}
 
 	quotedTableName := quoteIdentifier(tableName)
@@ -46,7 +47,7 @@ func InitSchema(db *sql.DB, tableName string) error {
 type Config struct {
 	// ConnectionString is the PostgreSQL connection string
 	ConnectionString string
-	// TableName is the name of the table to store events. Defaults to "events" if empty.
+	// TableName is the name of the table to store events. Must not be empty.
 	TableName string
 }
 
@@ -69,7 +70,7 @@ func newPgClient(config Config) (*pgClient, error) {
 
 	tableName := config.TableName
 	if tableName == "" {
-		tableName = "events"
+		return nil, fmt.Errorf("table name must not be empty")
 	}
 
 	return &pgClient{

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"testing"
+	"time"
 )
 
 func TestQuoteIdentifier(t *testing.T) {
@@ -59,14 +60,6 @@ func TestConfig_TableName(t *testing.T) {
 		expectedTable string
 	}{
 		{
-			name: "default table name when empty",
-			config: Config{
-				ConnectionString: "test-conn",
-				TableName:        "",
-			},
-			expectedTable: "events",
-		},
-		{
 			name: "custom table name",
 			config: Config{
 				ConnectionString: "test-conn",
@@ -90,12 +83,58 @@ func TestConfig_TableName(t *testing.T) {
 			// so we'll just test the table name assignment logic
 			tableName := tt.config.TableName
 			if tableName == "" {
-				tableName = "events"
+				t.Errorf("Table name should not be empty")
+				return
 			}
 
 			if tableName != tt.expectedTable {
 				t.Errorf("Expected table name %s, got %s", tt.expectedTable, tableName)
 			}
 		})
+	}
+}
+
+func TestInitSchema_EmptyTableName(t *testing.T) {
+	// Test that InitSchema rejects empty table names
+	err := InitSchema(nil, "")
+	if err == nil {
+		t.Error("InitSchema should return error for empty table name")
+	}
+	
+	expectedError := "table name must not be empty"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+	}
+}
+
+func TestNewPostgresEventStore_EmptyTableName(t *testing.T) {
+	// Test that NewPostgresEventStore returns an error for empty table names
+	store, err := NewPostgresEventStore(nil, "")
+	if err == nil {
+		t.Error("NewPostgresEventStore should return error for empty table name")
+	}
+	if store != nil {
+		t.Error("NewPostgresEventStore should return nil store for empty table name")
+	}
+	
+	expectedError := "table name must not be empty"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+	}
+}
+
+func TestNewPostgresEventConsumer_EmptyTableName(t *testing.T) {
+	// Test that NewPostgresEventConsumer returns an error for empty table names
+	consumer, err := NewPostgresEventConsumer(nil, "", 1*time.Second)
+	if err == nil {
+		t.Error("NewPostgresEventConsumer should return error for empty table name")
+	}
+	if consumer != nil {
+		t.Error("NewPostgresEventConsumer should return nil consumer for empty table name")
+	}
+	
+	expectedError := "table name must not be empty"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error %q, got %q", expectedError, err.Error())
 	}
 }

--- a/postgres/store.go
+++ b/postgres/store.go
@@ -15,9 +15,10 @@ type PostgresEventStore struct {
 }
 
 // NewPostgresEventStore creates a new PostgreSQL event store with the given database connection and table name.
-func NewPostgresEventStore(db *sql.DB, tableName string) eventstore.EventStore {
+// tableName must not be empty.
+func NewPostgresEventStore(db *sql.DB, tableName string) (eventstore.EventStore, error) {
 	if tableName == "" {
-		tableName = "events"
+		return nil, fmt.Errorf("table name must not be empty")
 	}
 
 	return &PostgresEventStore{
@@ -25,7 +26,7 @@ func NewPostgresEventStore(db *sql.DB, tableName string) eventstore.EventStore {
 			db:        db,
 			tableName: tableName,
 		},
-	}
+	}, nil
 }
 
 // Append adds new events to the given stream.


### PR DESCRIPTION
…stgreSQL constructor functions to return error (#31)

* Initial plan

* Remove default table name from PostgreSQL implementation



* Replace panic with error returns in NewPostgresEventStore and NewPostgresEventConsumer



---------