### PR TITLE
Add descending load logic and rename fields in EventStore interface (…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,20 @@ Used when loading events from a specific stream via `EventStore.Load()`:
 
 ```go
 type LoadOptions struct {
-    // AfterVersion specifies the version after which to start loading events
-    // - Use 0 to load from the beginning of the stream
-    // - Use a specific version to load events after that version
-    AfterVersion int64
+    // ExclusiveStartVersion specifies the version to use as exclusive starting point for loading events
+    // - In forward loading (Desc=false): gets events with version > ExclusiveStartVersion
+    // - In reverse loading (Desc=true): gets events with version < ExclusiveStartVersion (or all if 0)
+    ExclusiveStartVersion int64
     
     // Limit specifies the maximum number of events to return
     // - Use 0 for no limit (load all available events)
     // - Use positive integer to limit the batch size
     Limit int
+    
+    // Desc specifies whether to load events in descending order (from latest to oldest)
+    // - When true, loads events in descending order starting from the latest version
+    // - When false (default), loads events in ascending order
+    Desc bool
 }
 ```
 
@@ -125,10 +130,20 @@ func main() {
         panic(err)
     }
     
-    // Load events from the stream
+    // Load events from the stream (forward order - default behavior)
     loadedEvents, err := store.Load("user-123", eventstore.LoadOptions{
-        AfterVersion: 0,
+        ExclusiveStartVersion: 0,
         Limit: 10,
+    })
+    if err != nil {
+        panic(err)
+    }
+    
+    // Load latest events in descending order (newest first)
+    latestEvents, err := store.Load("user-123", eventstore.LoadOptions{
+        ExclusiveStartVersion: 0,
+        Limit: 5,    // Get latest 5 events
+        Desc: true,
     })
     if err != nil {
         panic(err)

--- a/eventstore.go
+++ b/eventstore.go
@@ -25,10 +25,16 @@ type Event struct {
 
 // LoadOptions contains options for loading events from a stream.
 type LoadOptions struct {
-	// AfterVersion specifies the version after which to start loading events
-	AfterVersion int64
+	// ExclusiveStartVersion specifies the version to use as exclusive starting point for loading events
+	// In forward loading (Desc=false): gets events with version > ExclusiveStartVersion
+	// In reverse loading (Desc=true): gets events with version < ExclusiveStartVersion (or all if 0)
+	ExclusiveStartVersion int64
 	// Limit specifies the maximum number of events to return
 	Limit int
+	// Desc specifies whether to load events in descending order (from latest to oldest)
+	// When true, loads events in descending order starting from the latest version
+	// When false (default), loads events in ascending order as before
+	Desc bool
 }
 
 // EventStore defines the core interface for event storage.

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -77,7 +77,7 @@ func main() {
 	// Load events from the stream
 	fmt.Printf("\n📖 Loading events from stream '%s'...\n", streamID)
 
-	loadedEvents, err := store.Load(streamID, eventstore.LoadOptions{AfterVersion: 0, Limit: 10})
+	loadedEvents, err := store.Load(streamID, eventstore.LoadOptions{ExclusiveStartVersion: 0, Limit: 10})
 	if err != nil {
 		log.Fatalf("Failed to load events: %v", err)
 	}
@@ -100,7 +100,7 @@ func main() {
 	fmt.Println("🔍 Demonstrating version-based loading...")
 	fmt.Println("Loading events starting from version 1:")
 
-	versionEvents, err := store.Load(streamID, eventstore.LoadOptions{AfterVersion: 1, Limit: 1})
+	versionEvents, err := store.Load(streamID, eventstore.LoadOptions{ExclusiveStartVersion: 1, Limit: 1})
 	if err != nil {
 		log.Fatalf("Failed to load events with version: %v", err)
 	}

--- a/examples/postgres-example/main.go
+++ b/examples/postgres-example/main.go
@@ -113,7 +113,7 @@ func main() {
 	// Load events from the stream
 	fmt.Printf("\n📖 Loading events from stream '%s'...\n", streamID)
 
-	loadedEvents, err := store.Load(streamID, eventstore.LoadOptions{AfterVersion: 0, Limit: 10})
+	loadedEvents, err := store.Load(streamID, eventstore.LoadOptions{ExclusiveStartVersion: 0, Limit: 10})
 	if err != nil {
 		log.Fatalf("Failed to load events: %v", err)
 	}
@@ -136,7 +136,7 @@ func main() {
 	fmt.Println("🔍 Demonstrating version-based loading...")
 	fmt.Println("Loading events starting from version 1:")
 
-	versionEvents, err := store.Load(streamID, eventstore.LoadOptions{AfterVersion: 1, Limit: 1})
+	versionEvents, err := store.Load(streamID, eventstore.LoadOptions{ExclusiveStartVersion: 1, Limit: 1})
 	if err != nil {
 		log.Fatalf("Failed to load events with version: %v", err)
 	}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -1,8 +1,11 @@
 package postgres
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/shogotsuneto/go-simple-eventstore"
 )
 
 func TestQuoteIdentifier(t *testing.T) {
@@ -136,5 +139,109 @@ func TestNewPostgresEventConsumer_EmptyTableName(t *testing.T) {
 	expectedError := "table name must not be empty"
 	if err.Error() != expectedError {
 		t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+	}
+}
+
+func TestBuildLoadQuery(t *testing.T) {
+	client := &pgClient{
+		tableName: "test_events",
+	}
+
+	tests := []struct {
+		name         string
+		streamID     string
+		opts         eventstore.LoadOptions
+		expectedSQL  []string // Parts that should be in the SQL
+		expectedArgs []interface{}
+	}{
+		{
+			name:     "forward loading with ExclusiveStartVersion",
+			streamID: "stream-1",
+			opts: eventstore.LoadOptions{
+				ExclusiveStartVersion: 10,
+				Limit:                 5,
+				Desc:                  false,
+			},
+			expectedSQL:  []string{"ORDER BY version ASC", "WHERE stream_id = $1 AND version > $2", "LIMIT $3"},
+			expectedArgs: []interface{}{"stream-1", int64(10), 5},
+		},
+		{
+			name:     "descending loading with ExclusiveStartVersion 0",
+			streamID: "stream-2",
+			opts: eventstore.LoadOptions{
+				ExclusiveStartVersion: 0,
+				Limit:                 10,
+				Desc:                  true,
+			},
+			expectedSQL:  []string{"ORDER BY version DESC", "WHERE stream_id = $1", "LIMIT $2"},
+			expectedArgs: []interface{}{"stream-2", 10},
+		},
+		{
+			name:     "descending loading with ExclusiveStartVersion > 0",
+			streamID: "stream-3",
+			opts: eventstore.LoadOptions{
+				ExclusiveStartVersion: 50,
+				Limit:                 20,
+				Desc:                  true,
+			},
+			expectedSQL:  []string{"ORDER BY version DESC", "WHERE stream_id = $1 AND version < $2", "LIMIT $3"},
+			expectedArgs: []interface{}{"stream-3", int64(50), 20},
+		},
+		{
+			name:     "forward loading without limit",
+			streamID: "stream-4",
+			opts: eventstore.LoadOptions{
+				ExclusiveStartVersion: 5,
+				Desc:                  false,
+			},
+			expectedSQL:  []string{"ORDER BY version ASC", "WHERE stream_id = $1 AND version > $2"},
+			expectedArgs: []interface{}{"stream-4", int64(5)},
+		},
+		{
+			name:     "descending loading without limit",
+			streamID: "stream-5",
+			opts: eventstore.LoadOptions{
+				ExclusiveStartVersion: 0,
+				Desc:                  true,
+			},
+			expectedSQL:  []string{"ORDER BY version DESC", "WHERE stream_id = $1"},
+			expectedArgs: []interface{}{"stream-5"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, args := client.buildLoadQuery(tt.streamID, tt.opts)
+
+			// Check that all expected SQL parts are present
+			for _, expectedPart := range tt.expectedSQL {
+				if !strings.Contains(query, expectedPart) {
+					t.Errorf("Expected query to contain %q, but got: %s", expectedPart, query)
+				}
+			}
+
+			// Check that arguments match
+			if len(args) != len(tt.expectedArgs) {
+				t.Errorf("Expected %d arguments, got %d: %v", len(tt.expectedArgs), len(args), args)
+				return
+			}
+
+			for i, expected := range tt.expectedArgs {
+				if args[i] != expected {
+					t.Errorf("Argument %d: expected %v, got %v", i, expected, args[i])
+				}
+			}
+
+			// Verify the table name is properly quoted in the query
+			expectedTableRef := `"test_events"`
+			if !strings.Contains(query, expectedTableRef) {
+				t.Errorf("Expected query to contain quoted table name %q, but got: %s", expectedTableRef, query)
+			}
+
+			// Verify the SELECT clause is present
+			if !strings.Contains(query, "SELECT event_id, event_type, event_data, metadata, timestamp, version") {
+				t.Errorf("Expected query to contain SELECT clause, but got: %s", query)
+			}
+		})
 	}
 }


### PR DESCRIPTION
…#33)

* Initial plan

* Implement reverse load functionality with comprehensive tests



* Update README documentation for reverse load functionality



* Rename fields and update reverse loading logic as requested

- Renamed 'Reverse' field to 'Desc' for clarity
- Renamed 'AfterVersion' to 'ExclusiveStartVersion' for better semantics
- Updated reverse loading logic: Desc=true with ExclusiveStartVersion=0 loads all events in descending order
- Updated reverse loading logic: Desc=true with ExclusiveStartVersion>0 loads events with version < ExclusiveStartVersion in descending order
- Updated all test cases and examples to use new field names and semantics
- All unit tests passing



* Update README documentation for new field names and semantics

- Updated LoadOptions documentation to reflect ExclusiveStartVersion and Desc fields
- Updated usage examples to demonstrate new descending loading semantics
- Clarified that ExclusiveStartVersion=0 with Desc=true loads all events in descending order
- Updated example showing loading events before a specific version in descending order
- All integration tests passing with new implementation



* Remove "as before" and backward compatibility mentions from README



* Remove ForwardLoadStillWorks test as requested



* Remove ForwardLoadStillWorks test from memory package



* Remove redundant README section and extract query building logic



* Reorder query construction to follow SQL statement order (SELECT->FROM->WHERE->ORDER BY->LIMIT)



* Remove TestLoadEvents_QueryGeneration test as requested



---------